### PR TITLE
Allow key deletion in original object #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/avrora/key-del.svg?branch=master)](https://travis-ci.org/avrora/key-del) [![Dependency Status](https://david-dm.org/avrora/key-del.svg)](https://david-dm.org/avrora/key-del)
 
-[![NPM](https://nodei.co/npm/key-del.png?downloads=true&stars=true)](https://nodei.co/npm/key-del/)
+[![NPM](https://nodei.co/npm/key-del.png?downloads=true&downloadRank=true)](https://nodei.co/npm/key-del/)
 
 [![NPM](https://nodei.co/npm-dl/key-del.png)](https://nodei.co/npm-dl/key-del/)
 
@@ -22,6 +22,7 @@
 ## Examples
 
 ```javascript
+
 var deleteKey = require('key-del')
 
 var originalObject = {
@@ -40,6 +41,14 @@ var result = deleteKey(originalObject, ['one', 'nestedOne'])
 
 console.log(result)
 // {two: 2, three: {nestedTwo: 4}}
+
+// if object should not be copied, set copy parameter to false (its true by default)
+var shallowAndDeleted = deleteKey(originalObject, ['one'], {copy: false});
+console.log(originalObject)
+// original object is modified
+// { one: 1, two: 2, three: { nestedOne: 3, nestedTwo: 4 } }
+
+
 ```
 
 ## Licence

--- a/index.js
+++ b/index.js
@@ -4,17 +4,32 @@
 
 var _ = require('lodash');
 
-var deleteKeysFromObject = function (object, keys) {
+var deleteKeysFromObject = function (object, keys, options) {
   var keysToDelete;
 
-  // do not modify original object
-  var finalObject = _.clone(object, true);
+  // deep copy by default
+  var isDeep = true;
+
+  // to preserve backwards compatibility, assume that only explicit options means shallow copy
+  if (_.isUndefined(options) == false) {
+    if (_.isBoolean(options.copy)) {
+      isDeep = options.copy;
+    }
+  }
+
+  // do not modify original object if copy is true (default)
+  var finalObject;
+  if (isDeep) {
+    finalObject = _.clone(object, isDeep);
+  } else {
+    finalObject = object;
+  }
 
   if (typeof finalObject === 'undefined') {
     throw new Error('undefined is not a valid object.');
   }
-  if (arguments.length !== 2) {
-    throw new Error("provide two parameters: object and list of keys");
+  if (arguments.length < 2) {
+    throw new Error("provide at least two parameters: object and list of keys");
   }
 
   // collect keys
@@ -28,11 +43,11 @@ var deleteKeysFromObject = function (object, keys) {
     for(var prop in finalObject) {
       if(finalObject.hasOwnProperty(prop)) {
         if (elem === prop) {
-          var deleteResult = delete finalObject[prop];
+          delete finalObject[prop];
         } else {
           // check nested attributes, if it's an object, and not array (thank you, Javascript)
           if (_.isObject(finalObject[prop]) && !_.isArray(finalObject[prop])) {
-            finalObject[prop] = deleteKeysFromObject(finalObject[prop], keysToDelete);
+            finalObject[prop] = deleteKeysFromObject(finalObject[prop], keysToDelete, options);
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "key-del",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Delete (nested) keys from JSON object",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -2,9 +2,10 @@
 
 /*global describe, it, before, beforeEach, after, afterEach */
 
-var assert = require("assert");
+var assert = require('assert');
 var should = require('should');
-var delKey = require("../index");
+var delKey = require('../index');
+var _      = require('lodash');
 
 describe('del-key', function() {
   it('shall check parameters', function() {
@@ -73,4 +74,21 @@ describe('del-key', function() {
     assert.equal(result.c.e.g, 8, 'key shall be kept');
   });
 
-})
+  it('shall handle deep copy', function() {
+
+    var objectToDeleteKeyFrom = [{ "one": "first", "two": "second"}];
+    var keyToDelete = ['does not exist'];
+    var deep = delKey(objectToDeleteKeyFrom, keyToDelete, {copy:true});
+    assert.equal(objectToDeleteKeyFrom[0] === deep[0], false, 'objects are cloned explicetely');
+    var deepByDefault = delKey(objectToDeleteKeyFrom, keyToDelete);
+    assert.equal(objectToDeleteKeyFrom[0] === deepByDefault[0], false, 'object are cloned by default');
+  });
+
+  it('shall handle shallow copy', function() {
+
+    var objectToDeleteKeyFrom = { "one": "first", "two": "second"};
+    var shallow = delKey(objectToDeleteKeyFrom, 'two', {copy:false});
+    assert.equal(objectToDeleteKeyFrom === shallow, true, 'should be the same object');
+  });
+
+});


### PR DESCRIPTION
Add options to allow modifying original object:

key-del(originalObject, 'keyToDelete', {copy: false}) // will delete keyToDelete from original object